### PR TITLE
Add support for session/set_mode request

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -450,6 +450,22 @@ and https://agentclientprotocol.com/protocol/schema#promptresponse."
     (:params . ((sessionId . ,session-id)
                 (prompt . ,(vconcat prompt))))))
 
+(cl-defun acp-make-session-set-mode-request (&key session-id mode-id)
+  "Instantiate a \"session/set_mode\" request.
+
+SESSION-ID is the ID of the session to change the mode for.
+MODE-ID is the mode to set (e.g., \"default\", \"plan\", \"acceptEdits\",
+\"bypassPermissions\").
+
+See https://agentclientprotocol.com/protocol/session-modes"
+  (unless session-id
+    (error ":session-id is required"))
+  (unless mode-id
+    (error ":mode-id is required"))
+  `((:method . "session/set_mode")
+    (:params . ((sessionId . ,session-id)
+                (modeId . ,mode-id)))))
+
 (cl-defun acp-make-session-request-permission-response (&key request-id option-id)
   "Instantiate a \"session/request_permission\" response.
 


### PR DESCRIPTION
## Summary

Adds `acp-make-session-set-mode-request` function to create requests for changing ACP session permission modes during an active session.

## What it does

- Creates a `session/set_mode` JSON-RPC request with `sessionId` and `modeId`
- Allows clients to switch between different agent operating modes like:
  - `"default"` - Always ask for permission
  - `"plan"` - Read-only mode, no modifications
  - `"acceptEdits"` - Auto-accept file edit permissions
  - `"bypassPermissions"` - Skip all permission prompts

## Background

Available modes are advertised by the server in the `session/new` response under the `modes` field, which contains:
- `availableModes`: array of mode objects with `id`, `name`, and `description`
- `currentModeId`: the currently active mode

This PR enables clients like agent-shell to implement UI for viewing and switching between these modes.

## Documentation

See https://agentclientprotocol.com/protocol/session-modes for protocol specification.

## Related

This is a dependency for https://github.com/xenodium/agent-shell/pull/79 which adds permission mode cycling to agent-shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)