### PR TITLE
Add TRAMP support via file-handler

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -42,6 +42,10 @@
   (require 'cl-lib))
 (require 'acp-traffic)
 
+;; TRAMP variables for remote process execution
+(defvar tramp-use-ssh-controlmaster-options)
+(defvar tramp-ssh-controlmaster-options)
+
 (defconst acp--jsonrpc-version "2.0")
 
 (defvar acp-logging-enabled nil)
@@ -98,7 +102,7 @@ functions for advanced customization or testing."
     (error ":client is required"))
   (unless (map-elt client :command)
     (error ":command is required"))
-  (unless (executable-find (map-elt client :command))
+  (unless (executable-find (map-elt client :command) (file-remote-p default-directory))
     (error "\"%s\" command line utility not found.  Please install it" (map-elt client :command)))
   (when (acp--client-started-p client)
     (error "Client already started"))
@@ -110,39 +114,49 @@ functions for advanced customization or testing."
          (stderr-buffer (get-buffer-create (format "acp-client-stderr(%s)-%s"
                                                    (map-elt client :command)
                                                    (map-elt client :instance-count))))
-         (stderr-proc (make-pipe-process
-                       :name (format "acp-client-stderr(%s)-%s"
-                                     (map-elt client :command)
-                                     (map-elt client :instance-count))
-                       :buffer stderr-buffer
-                       :filter (lambda (_process raw-output)
-                                 (acp--log client "STDERR" "%s" (string-trim raw-output))
-                                 (when-let ((std-error (cond
-                                                        ((acp--parse-stderr-api-error raw-output)
-                                                         (acp--parse-stderr-api-error raw-output))
-                                                        ((not (string-empty-p (string-trim raw-output)))
-                                                         ;; Fallback: create a generic error response
-                                                         `((code . -32603)
-                                                           (message . ,raw-output))))))
-                                   (acp--log client "API-ERROR" "%s" (string-trim raw-output))
-                                   (dolist (handler (map-elt client :error-handlers))
-                                     (funcall handler std-error)))))))
-    (let ((process (make-process
-                    :name (format "acp-client(%s)-%s"
-                                  (map-elt client :command)
-                                  (map-elt client :instance-count))
-                    :command (cons (map-elt client :command)
-                                   (map-elt client :command-params))
-                    :stderr stderr-proc
-                    :connection-type 'pipe
-                    :filter (lambda (_proc input)
-                              (acp--log client "INCOMING TEXT" "%s" input)
-                              (setq pending-input (concat pending-input input))
-                              (let ((start 0) pos)
-                                (while (setq pos (string-search "\n" pending-input start))
-                                  (let ((json (substring pending-input start pos)))
-                                    (acp--log client "INCOMING LINE" "%s" json)
-                                    (when-let* ((object (condition-case nil
+         ;; For TRAMP (file-handler), we can only use a buffer for stderr.
+         ;; For local execution, we use a pipe process for live error parsing.
+         (use-file-handler (file-remote-p default-directory))
+         (stderr-proc (unless use-file-handler
+                        (make-pipe-process
+                         :name (format "acp-client-stderr(%s)-%s"
+                                       (map-elt client :command)
+                                       (map-elt client :instance-count))
+                         :buffer stderr-buffer
+                         :filter (lambda (_process raw-output)
+                                   (acp--log client "STDERR" "%s" (string-trim raw-output))
+                                   (when-let ((std-error (cond
+                                                          ((acp--parse-stderr-api-error raw-output)
+                                                           (acp--parse-stderr-api-error raw-output))
+                                                          ((not (string-empty-p (string-trim raw-output)))
+                                                           ;; Fallback: create a generic error response
+                                                           `((code . -32603)
+                                                             (message . ,raw-output))))))
+                                     (acp--log client "API-ERROR" "%s" (string-trim raw-output))
+                                     (dolist (handler (map-elt client :error-handlers))
+                                       (funcall handler std-error))))))))
+    ;; Disable SSH ControlMaster for TRAMP - it can't handle large data (see eglot bug#61350)
+    (let ((tramp-use-ssh-controlmaster-options (if use-file-handler 'suppress tramp-use-ssh-controlmaster-options))
+          (tramp-ssh-controlmaster-options (if use-file-handler "-o ControlMaster=no -o ControlPath=none" tramp-ssh-controlmaster-options)))
+      (let ((process (make-process
+                      :name (format "acp-client(%s)-%s"
+                                    (map-elt client :command)
+                                    (map-elt client :instance-count))
+                      :command (cons (map-elt client :command)
+                                     (map-elt client :command-params))
+                      :stderr (or stderr-proc stderr-buffer)
+                      :connection-type 'pipe
+                      :coding 'utf-8-emacs-unix
+                      :noquery t
+                      :file-handler use-file-handler
+                      :filter (lambda (_proc input)
+                                (acp--log client "INCOMING TEXT" "%s" input)
+                                (setq pending-input (concat pending-input input))
+                                (let ((start 0) pos)
+                                  (while (setq pos (string-search "\n" pending-input start))
+                                    (let ((json (substring pending-input start pos)))
+                                      (acp--log client "INCOMING LINE" "%s" json)
+                                      (when-let* ((object (condition-case nil
                                                             (acp--parse-json json)
                                                           (error
                                                            (acp--log client "JSON PARSE ERROR" "Invalid JSON: %s" json)
@@ -184,7 +198,7 @@ functions for advanced customization or testing."
                                   (delete-process stderr-proc))
                                 (when (buffer-live-p stderr-buffer)
                                   (kill-buffer stderr-buffer))))))
-      (map-put! client :process process))))
+      (map-put! client :process process)))))
 
 (cl-defun acp-subscribe-to-notifications (&key client on-notification buffer)
   "Subscribe to incoming CLIENT notifications.


### PR DESCRIPTION
Enable transparent remote process execution when default-directory is a TRAMP path, similar to how eglot handles LSP servers.

## Changes
- Add :file-handler to make-process for TRAMP support
- Use buffer for stderr with TRAMP (pipe not supported)
- Declare TRAMP variables to avoid void-variable errors
- Disable SSH ControlMaster for TRAMP (can't handle large data)
- Add :coding and :noquery like eglot
- Check executable-find on remote host

## Context
This is needed for TRAMP support in agent-shell (PR #205). With this change, agents run transparently on remote hosts when working in a TRAMP directory.

## References
- [eglot.el implementation](https://github.com/emacs-mirror/emacs/blob/master/lisp/progmodes/eglot.el#L1788)
- [Emacs bug#61350](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=61350) for ControlMaster issue