### PR TITLE
Add acp-make-session-resume-request for session/resume support

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -524,6 +524,30 @@ See https://docs.claude.com/en/api/agent-sdk/typescript"
     (:params . ((sessionId . ,session-id)
                 (modelId . ,model-id)))))
 
+(cl-defun acp-make-session-resume-request (&key session-id cwd mcp-servers)
+  "Instantiate a \"session/resume\" request.
+
+SESSION-ID is the ID of the session to resume.
+CWD is the current working directory for the resumed session.
+MCP-SERVERS is an optional list of MCP servers to use.
+
+This method resumes an existing session without returning previous messages
+\(unlike `session/load').  Only available if the agent advertises the
+`session.resume' capability.
+
+Note: This is an unstable ACP feature.
+
+See https://agentclientprotocol.com/protocol/schema#resumesessionrequest
+and https://agentclientprotocol.com/protocol/schema#resumesessionresponse."
+  (unless session-id
+    (error ":session-id is required"))
+  (unless cwd
+    (error ":cwd is required"))
+  `((:method . "session/resume")
+    (:params . ((sessionId . ,session-id)
+                (cwd . ,(expand-file-name cwd))
+                (mcpServers . ,(or mcp-servers []))))))
+
 (cl-defun acp-make-session-request-permission-response (&key request-id option-id cancelled)
   "Instantiate a \"session/request_permission\" response.
 


### PR DESCRIPTION
## Summary
- Adds `acp-make-session-resume-request` function to support the unstable ACP `session/resume` method
- Enables clients to resume existing sessions without replaying message history

## Changes
- New function `acp-make-session-resume-request` with `:session-id`, `:cwd`, and `:mcp-servers` parameters
- Follows existing patterns from other session request functions
- Includes docstring with links to ACP protocol documentation

## Notes
- This is an unstable ACP feature (as noted in docstring)
- Required by agent-shell for session resume support (xenodium/agent-shell#105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)