### PR TITLE
Support file-handler ACP client processes

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -9,6 +9,9 @@
 
 (defconst acp-package-version "0.11.3")
 
+(defconst acp-file-handler-process-support t
+  "Non-nil when ACP client processes honor Emacs file handlers.")
+
 ;; This package is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)
@@ -105,7 +108,8 @@ the error is logged."
     (error ":client is required"))
   (unless (map-elt client :command)
     (error ":command is required"))
-  (unless (executable-find (map-elt client :command))
+  (unless (executable-find (map-elt client :command)
+                           (file-remote-p default-directory))
     (error "\"%s\" command line utility not found.  Please install it" (map-elt client :command)))
   (when (acp--client-started-p client)
     (error "Client already started"))
@@ -119,33 +123,36 @@ the error is logged."
          (stderr-buffer (get-buffer-create (format "acp-client-stderr(%s)-%s"
                                                    (map-elt client :command)
                                                    (map-elt client :instance-count))))
-         (stderr-proc (make-pipe-process
-                       :name (format "acp-client-stderr(%s)-%s"
-                                     (map-elt client :command)
-                                     (map-elt client :instance-count))
-                       :buffer stderr-buffer
-                       :noquery t
-                       :filter (lambda (_process raw-output)
-                                 (acp--log client "STDERR" "%s" (string-trim raw-output))
-                                 (when-let ((std-error (cond
-                                                        ((acp--parse-stderr-api-error raw-output)
-                                                         (acp--parse-stderr-api-error raw-output))
-                                                        ((not (string-empty-p (string-trim raw-output)))
-                                                         ;; Fallback: create a generic error response
-                                                         `((code . -32603)
-                                                           (message . ,raw-output))))))
-                                   (acp--log client "API-ERROR" "%s" (string-trim raw-output))
-                                   (dolist (handler (map-elt client :error-handlers))
-                                     (funcall handler std-error)))))))
+         (use-file-handler (file-remote-p default-directory))
+         (stderr-proc (unless use-file-handler
+                        (make-pipe-process
+                         :name (format "acp-client-stderr(%s)-%s"
+                                       (map-elt client :command)
+                                       (map-elt client :instance-count))
+                         :buffer stderr-buffer
+                         :noquery t
+                         :filter (lambda (_process raw-output)
+                                   (acp--log client "STDERR" "%s" (string-trim raw-output))
+                                   (when-let ((std-error (cond
+                                                          ((acp--parse-stderr-api-error raw-output)
+                                                           (acp--parse-stderr-api-error raw-output))
+                                                          ((not (string-empty-p (string-trim raw-output)))
+                                                           ;; Fallback: create a generic error response
+                                                           `((code . -32603)
+                                                             (message . ,raw-output))))))
+                                     (acp--log client "API-ERROR" "%s" (string-trim raw-output))
+                                     (dolist (handler (map-elt client :error-handlers))
+                                       (funcall handler std-error))))))))
     (let ((process (make-process
                     :name (format "acp-client(%s)-%s"
                                   (map-elt client :command)
                                   (map-elt client :instance-count))
                     :command (cons (map-elt client :command)
                                    (map-elt client :command-params))
-                    :stderr stderr-proc
+                    :stderr (or stderr-proc stderr-buffer)
                     :connection-type 'pipe
                     :noquery t
+                    :file-handler use-file-handler
                     :filter (lambda (_proc input)
                               (acp--log client "INCOMING TEXT" "%s" input)
                               (setq pending-input (concat pending-input input))
@@ -200,10 +207,13 @@ the error is logged."
                                   (setq start (1+ pos)))
                                 (setq pending-input (substring pending-input start))))
                     :sentinel (lambda (_process _event)
-                                (when (process-live-p stderr-proc)
+                                (when (and stderr-proc
+                                           (process-live-p stderr-proc))
                                   (delete-process stderr-proc))
                                 (when (buffer-live-p stderr-buffer)
                                   (kill-buffer stderr-buffer))))))
+      (when use-file-handler
+        (accept-process-output process 0.1))
       (map-put! client :process process))))
 
 (cl-defun acp-subscribe-to-notifications (&key client on-notification buffer)


### PR DESCRIPTION
## Summary

Allow ACP client processes to start through Emacs file handlers when `default-directory` is remote.

## Details

This keeps local process startup unchanged, but when `default-directory` is remote it:

- uses remote-aware `executable-find`
- passes `:file-handler` to `make-process`
- uses a buffer for stderr because remote file handlers may not support a pipe process for stderr
- exposes `acp-file-handler-process-support` so integrations can feature-detect the behavior

The intent is to keep remote execution support generic at the ACP process layer, letting file handlers such as TRAMP or TRAMP-RPC own the actual transport.

## Validation

- `emacs -Q --batch -L . -f batch-byte-compile acp.el`
- locally smoke-tested with `agent-shell` over `/rpc:dev:/tmp/`
