### PR TITLE
Invoke `:on-failure` when agent process dies

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -199,9 +199,11 @@ the error is logged."
                                                        (setq message-queue-busy nil))))))
                                   (setq start (1+ pos)))
                                 (setq pending-input (substring pending-input start))))
-                    :sentinel (lambda (_process _event)
+                    :sentinel (lambda (process event)
                                 (when (buffer-live-p stderr-buffer)
-                                  (kill-buffer stderr-buffer))))))
+                                  (kill-buffer stderr-buffer))
+                                (when (memq (process-status process) '(exit signal))
+                                  (acp--fail-pending-requests :client client :event event))))))
       (map-put! client :process process))))
 
 (defun acp--make-internal-error (message)
@@ -221,6 +223,37 @@ agent over the wire.  Code -32603 is JSON-RPC's \"Internal error\"."
         (if (>= (cdr (func-arity callback)) 2)
             (funcall callback error-data message)
           (funcall callback error-data))))))
+
+(cl-defun acp--fail-pending-requests (&key client event)
+  "Invoke `:on-failure' for any pending requests on CLIENT.
+
+EVENT is the sentinel event string describing why the process ended.
+Each pending callback receives a synthetic JSON-RPC error matching the
+shape used by `acp--route-incoming-message' for response failures."
+  (let* ((pending (map-elt client :pending-requests))
+         (trimmed (string-trim event))
+         (error-message "Agent process ended before completing request")
+         (error-data (acp--make-internal-error
+                      (if (string-empty-p trimmed)
+                          error-message
+                        (format "%s: %s" error-message trimmed)))))
+    (map-put! client :pending-requests nil)
+    (dolist (entry pending)
+      (when-let ((incoming-response (cdr entry))
+                 ((map-elt incoming-response :on-failure)))
+        (condition-case-unless-debug err
+            (acp--call-request-failure
+             :client client
+             :incoming-response incoming-response
+             :error-data error-data
+             :message (acp--make-message
+                       :object `((jsonrpc . ,acp--jsonrpc-version)
+                                 (id . ,(car entry))
+                                 (error . ,error-data))
+                       :json nil))
+          (error
+           (acp--log client "REQUEST FAILURE CALLBACK ERROR"
+                     "Failed with error: %S" err)))))))
 
 (cl-defun acp-subscribe-to-notifications (&key client on-notification buffer)
   "Subscribe to incoming CLIENT notifications.

--- a/acp.el
+++ b/acp.el
@@ -130,8 +130,7 @@ the error is logged."
                                             (acp--parse-stderr-api-error raw-output))
                                            ((not (string-empty-p (string-trim raw-output)))
                                             ;; Fallback: create a generic error response
-                                            `((code . -32603)
-                                              (message . ,raw-output))))))
+                                            (acp--make-internal-error raw-output)))))
                       (acp--log client "API-ERROR" "%s" (string-trim raw-output))
                       (dolist (handler (map-elt client :error-handlers))
                         (funcall handler std-error)))))
@@ -204,6 +203,13 @@ the error is logged."
                                 (when (buffer-live-p stderr-buffer)
                                   (kill-buffer stderr-buffer))))))
       (map-put! client :process process))))
+
+(defun acp--make-internal-error (message)
+  "Build a synthetic JSON-RPC-shaped error alist with MESSAGE.
+
+Used for errors synthesized locally rather than received from the
+agent over the wire.  Code -32603 is JSON-RPC's \"Internal error\"."
+  (acp-make-error :code -32603 :message message))
 
 (cl-defun acp-subscribe-to-notifications (&key client on-notification buffer)
   "Subscribe to incoming CLIENT notifications.

--- a/acp.el
+++ b/acp.el
@@ -211,6 +211,17 @@ Used for errors synthesized locally rather than received from the
 agent over the wire.  Code -32603 is JSON-RPC's \"Internal error\"."
   (acp-make-error :code -32603 :message message))
 
+(cl-defun acp--call-request-failure (&key client incoming-response error-data message)
+  "Invoke INCOMING-RESPONSE's failure callback with ERROR-DATA and MESSAGE."
+  (with-temp-buffer ;; Fallback to a temp buffer
+    (with-current-buffer (or (map-elt incoming-response :buffer)
+                             (map-elt client :context-buffer)
+                             (current-buffer))
+      (let ((callback (map-elt incoming-response :on-failure)))
+        (if (>= (cdr (func-arity callback)) 2)
+            (funcall callback error-data message)
+          (funcall callback error-data))))))
+
 (cl-defun acp-subscribe-to-notifications (&key client on-notification buffer)
   "Subscribe to incoming CLIENT notifications.
 
@@ -815,14 +826,11 @@ ON-REQUEST is of the form (lambda (request))."
        (acp--log-traffic client 'incoming 'response message)
        (map-put! client :pending-requests (map-delete (map-elt client :pending-requests) .id))
        (if (map-elt incoming-response :on-failure)
-           (with-temp-buffer ;; Fallback to a temp buffer
-             (with-current-buffer (or (map-elt incoming-response :buffer)
-                                      (map-elt client :context-buffer)
-                                      (current-buffer))
-               (let ((callback (map-elt incoming-response :on-failure)))
-                 (if (>= (cdr (func-arity callback)) 2)
-                     (funcall callback .error message)
-                   (funcall callback .error)))))
+           (acp--call-request-failure
+            :client client
+            :incoming-response incoming-response
+            :error-data .error
+            :message message)
          (acp--log client nil "Unhandled error:\n\n%s" message))
        t)
 

--- a/tests/acp-test.el
+++ b/tests/acp-test.el
@@ -63,6 +63,21 @@
     (should (equal result log3))
     (should (<= (string-bytes result) max-bytes))))
 
+(ert-deftest acp-test-sync-request-fails-when-agent-exits-after-read ()
+  "Synchronous requests error instead of waiting forever after agent exit."
+  (let ((client (acp-make-client
+                 :command "sh"
+                 :command-params '("-c" "IFS= read -r _; exit 42"))))
+    (unwind-protect
+        (should-error
+         (acp-send-request
+          :client client
+          :request '((:method . "initialize"))
+          :sync t))
+      (when-let ((process (map-elt client :process))
+                 ((process-live-p process)))
+        (delete-process process)))))
+
 (provide 'acp-test)
 
 ;;; acp-test.el ends here


### PR DESCRIPTION
## Problem
`acp.el` only invokes `:on-failure` when the agent process emits a JSON-RPC error response. If the process dies without sending a response, the callback never fires.

In agent-shell, this can cause the `Loading...` indicator to stay up forever if the agent crashes during startup; its hide-on-error subscriber waits indefinitely for an `'error` event that's supposed to be emitted by the handshake's `:on-failure`.

## Solution
When the process dies, emit a synthetic JSON-RPC error.