### PR TITLE
Retain child's stderr chunks as they come.

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -137,8 +137,9 @@ the error is logged."
                     (when-let* ((std-error (cond
                                             ((acp--parse-stderr-api-error raw-output)
                                              (acp--parse-stderr-api-error raw-output))
-                                            ((not (string-empty-p (string-trim raw-output)))
-                                             ;; Fallback: create a generic error response
+                                            ((not (string-empty-p raw-output))
+                                             ;; Preserve whitespace-only chunks: consumers
+                                             ;; append messages to reconstruct stderr.
                                              (acp--make-internal-error raw-output)))))
                       (acp--log client "API-ERROR" "%s" (string-trim raw-output))
                       (dolist (handler (map-elt client :error-handlers))

--- a/tests/acp-test.el
+++ b/tests/acp-test.el
@@ -32,6 +32,31 @@
       (when (buffer-live-p log-buffer)
         (kill-buffer log-buffer)))))
 
+(ert-deftest acp-test-stderr-preserves-whitespace-only-chunks ()
+  "Forward stderr chunks unchanged so consumers can concatenate them."
+  (let ((client (acp-make-client :command "cat"))
+        (acp-logging-enabled nil)
+        (chunks '("hello" " " "world" "\n" "\t" "next\n"))
+        stderr-buffer received)
+    (acp-subscribe-to-errors
+     :client client
+     :on-error (lambda (error-data)
+                 (should (= (map-elt error-data 'code) -32603))
+                 (push (map-elt error-data 'message) received)))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'make-process)
+                     (lambda (&rest args)
+                       (setq stderr-buffer (plist-get args :stderr))
+                       nil)))
+            (acp--start-client :client client))
+          (with-current-buffer stderr-buffer
+            (dolist (chunk chunks)
+              (insert chunk)))
+          (should (equal (nreverse received) chunks)))
+      (when (buffer-live-p stderr-buffer)
+        (kill-buffer stderr-buffer)))))
+
 (ert-deftest acp-test-trim-log-buffer-unibyte ()
   "Trim unibyte logs on whole-message boundaries."
   (let* ((msg1 (cons "A" "one"))


### PR DESCRIPTION
Previously, the stderr chunk capturing would trim each chunk, causing whitespace chunks (thus real whitespace from each message) to be lost.

Now, this will retain whitespace.