### PR TITLE
Keep draining the message queue after a non-local exit

### DIFF
--- a/acp.el
+++ b/acp.el
@@ -124,6 +124,7 @@ the error is logged."
          (pending-input "")
          (message-queue nil)
          (message-queue-busy nil)
+         (drain-queue nil)
          (process-environment (append (map-elt client :environment-variables)
                                       process-environment))
          (stderr-buffer (get-buffer-create (format "acp-client-stderr(%s)-%s"
@@ -145,6 +146,51 @@ the error is logged."
                       (dolist (handler (map-elt client :error-handlers))
                         (funcall handler std-error)))))
                 nil t))
+    ;; Drains the queue in order, resetting the busy flag via
+    ;; `unwind-protect' and rescheduling itself when messages are left
+    ;; behind.  A non-local exit (a `quit' from C-g, or an error while
+    ;; `debug-on-error' is set) would otherwise unwind out of the timer
+    ;; with the queue still flagged busy, so no later message is ever
+    ;; routed and the client silently stops responding.
+    (setq drain-queue
+          (lambda ()
+            (unwind-protect
+                (while message-queue
+                  ;; Bind print variables so the debugger
+                  ;; can safely print the client alist
+                  ;; without infinite recursion (#360).
+                  (let ((message (car message-queue))
+                        ;; Handle circular refs in client alist.
+                        (print-circle t)
+                        ;; Cap nesting depth.
+                        (print-level 25)
+                        ;; Cap list elements printed.
+                        (print-length 200))
+                    (setq message-queue (cdr message-queue))
+                    (acp--route-incoming-message
+                     :message message
+                     :client client
+                     :on-notification
+                     (lambda (notification)
+                       (dolist (handler (map-elt client :notification-handlers))
+                         (condition-case-unless-debug err
+                             (funcall handler notification)
+                           (error
+                            (acp--log client "NOTIFICATION HANDLER ERROR"
+                                      "Failed with error: %S" err)))))
+                     :on-request
+                     (lambda (request)
+                       (dolist (handler (map-elt client :request-handlers))
+                         (condition-case-unless-debug err
+                             (funcall handler request)
+                           (error
+                            (acp--log client "REQUEST HANDLER ERROR"
+                                      "Failed with error: %S" err))))))))
+              ;; Keep the busy flag raised while a drain is still
+              ;; pending, so the filter doesn't schedule a second one.
+              (if message-queue
+                  (run-at-time 0 nil drain-queue)
+                (setq message-queue-busy nil)))))
     (let ((process (make-process
                     :name (format "acp-client(%s)-%s"
                                   (map-elt client :command)
@@ -173,40 +219,7 @@ the error is logged."
                                                     (list (acp--make-message :json json :object object))))
                                       (unless message-queue-busy
                                         (setq message-queue-busy t)
-                                        (run-at-time 0 nil
-                                                     (lambda ()
-                                                       (while message-queue
-                                                         ;; Bind print variables so the debugger
-                                                         ;; can safely print the client alist
-                                                         ;; without infinite recursion (#360).
-                                                         (let ((message (car message-queue))
-                                                               ;; Handle circular refs in client alist.
-                                                               (print-circle t)
-                                                               ;; Cap nesting depth.
-                                                               (print-level 25)
-                                                               ;; Cap list elements printed.
-                                                               (print-length 200))
-                                                           (setq message-queue (cdr message-queue))
-                                                           (acp--route-incoming-message
-                                                            :message message
-                                                            :client client
-                                                            :on-notification
-                                                            (lambda (notification)
-                                                              (dolist (handler (map-elt client :notification-handlers))
-                                                                (condition-case-unless-debug err
-                                                                    (funcall handler notification)
-                                                                  (error
-                                                                   (acp--log client "NOTIFICATION HANDLER ERROR"
-                                                                             "Failed with error: %S" err)))))
-                                                            :on-request
-                                                            (lambda (request)
-                                                              (dolist (handler (map-elt client :request-handlers))
-                                                                (condition-case-unless-debug err
-                                                                    (funcall handler request)
-                                                                  (error
-                                                                   (acp--log client "REQUEST HANDLER ERROR"
-                                                                             "Failed with error: %S" err))))))))
-                                                       (setq message-queue-busy nil))))))
+                                        (run-at-time 0 nil drain-queue))))
                                   (setq start (1+ pos)))
                                 (setq pending-input (substring pending-input start))))
                     :sentinel (lambda (process event)

--- a/tests/acp-test.el
+++ b/tests/acp-test.el
@@ -208,6 +208,76 @@
   "Refuse to build a request without a cwd."
   (should-error (acp-make-session-list-request :cursor "page-2")))
 
+(defun acp-test--captured-filter (client)
+  "Start CLIENT with a stubbed process and return its `:filter'."
+  (let (filter)
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest args)
+                 (setq filter (plist-get args :filter))
+                 nil)))
+      (acp--start-client :client client))
+    filter))
+
+(defun acp-test--notification-line (n)
+  "Return a newline-terminated notification carrying number N."
+  (format "{\"jsonrpc\":\"2.0\",\"method\":\"session/update\",\"params\":{\"n\":%d}}\n" n))
+
+(defun acp-test--drain (&optional timeout)
+  "Run pending timers for up to TIMEOUT seconds, defaulting to 1."
+  (let ((deadline (+ (float-time) (or timeout 1))))
+    (while (< (float-time) deadline)
+      ;; The drain reschedules itself, so keep pumping rather than
+      ;; assuming a single timer runs everything.
+      (condition-case nil
+          (accept-process-output nil 0.02)
+        (quit nil)))))
+
+(ert-deftest acp-test-drain-survives-quitting-notification-handler ()
+  "Keep routing queued messages after a handler exits non-locally."
+  (let* ((acp-logging-enabled nil)
+         (client (acp-make-client :command "cat"))
+         received filter)
+    (acp-subscribe-to-notifications
+     :client client
+     :on-notification (lambda (notification)
+                        (let ((n (map-nested-elt notification '(params n))))
+                          (push n received)
+                          ;; Stand in for C-g arriving mid-drain.
+                          (when (= n 2)
+                            (signal 'quit nil)))))
+    (unwind-protect
+        (progn
+          (setq filter (acp-test--captured-filter client))
+          (funcall filter nil (mapconcat #'acp-test--notification-line '(1 2 3 4) ""))
+          (acp-test--drain)
+          ;; 3 and 4 are queued behind the quitting handler: without a
+          ;; rescheduled drain they are never routed.
+          (should (equal (nreverse received) '(1 2 3 4))))
+      (acp-shutdown :client client))))
+
+(ert-deftest acp-test-drain-unwedges-queue-after-quitting-handler ()
+  "Route messages arriving after a handler exited non-locally."
+  (let* ((acp-logging-enabled nil)
+         (client (acp-make-client :command "cat"))
+         received filter)
+    (acp-subscribe-to-notifications
+     :client client
+     :on-notification (lambda (notification)
+                        (let ((n (map-nested-elt notification '(params n))))
+                          (push n received)
+                          (when (= n 1)
+                            (signal 'quit nil)))))
+    (unwind-protect
+        (progn
+          (setq filter (acp-test--captured-filter client))
+          (funcall filter nil (acp-test--notification-line 1))
+          (acp-test--drain)
+          ;; A stuck busy flag would swallow every later message.
+          (funcall filter nil (acp-test--notification-line 2))
+          (acp-test--drain)
+          (should (equal (nreverse received) '(1 2))))
+      (acp-shutdown :client client))))
+
 (provide 'acp-test)
 
 ;;; acp-test.el ends here


### PR DESCRIPTION
### What happens

An agent shell freezes mid-answer: the spinner keeps running, no further
text is rendered, and the buffer never gets its prompt back. The shell
stays dead for the rest of the session — every later turn is swallowed
too. Restarting the client is the only way out.

The agent is fine. It finished the turn and sent everything.

### Root cause

`acp--start-client`'s queue drain runs from a timer and clears
`message-queue-busy` on its very last line:

```elisp
(unless message-queue-busy
  (setq message-queue-busy t)
  (run-at-time 0 nil
               (lambda ()
                 (while message-queue
                   ... (acp--route-incoming-message ...))
                 (setq message-queue-busy nil))))   ; skipped on non-local exit
```

Any non-local exit out of the `while` skips that reset. The flag stays
raised, so the filter's `(unless message-queue-busy ...)` never fires
again, and every subsequent message is appended to a queue that nobody
drains — including the `session/prompt` response that ends the turn.

`condition-case-unless-debug` around the notification and request
handlers contains `error`, but **not** `quit`. So a `C-g` arriving while
the drain is rendering a chunk is enough to wedge the client
permanently. With `acp-logging-enabled` nil there is no trace of it
anywhere.

This is the same failure mode 7335aed ("Contain erroring response
callbacks") described:

> an erroring callback would otherwise unwind out of the timer draining
> the message queue, leaving it flagged busy so no later message is ever
> routed

That commit contained `error` in all three handler paths. `quit` still
escapes all three, and the missing `unwind-protect` means any future
non-local exit reintroduces the bug.

### Evidence from the wild

A frozen `agent-shell` buffer, inspected through the filter closure's
captured cells:

| | wedged client | three healthy clients |
|---|---|---|
| `message-queue-busy` | `t` | `nil` |
| `message-queue` | **528 messages** | `0` |
| `pending-input` | `0` | `0` |

`pending-input` empty rules out a framing desync — every byte had been
parsed into a complete JSON-RPC message. All 528 were simply never
routed:

- **528 = 527 × `session/update` + 1 × result.**
- Queue head: an `agent_message_chunk` whose text is the exact next
  token after the point the buffer stopped rendering.
- Queue tail: `{"id":13,"result":{"stopReason":"end_turn",...}}` — the
  turn-completion response, stranded. That is why the spinner never
  stopped.

The agent's own transcript showed the turn had completed normally
(`stop_reason: end_turn`, full 2378-character answer) about four hours
earlier.

### The fix

Hoist the drain into a `drain-queue` closure and:

1. reset `message-queue-busy` from an `unwind-protect`, so no exit path
   can leave it raised;
2. reschedule while messages are left behind, so an interrupted drain
   resumes instead of stalling.

The busy flag stays raised across a reschedule, so the filter still
won't start a second concurrent drain.

Net effect of a `C-g` landing mid-drain: the message being rendered is
dropped (one chunk of text), and the rest of the queue — crucially the
turn-ending response — still gets routed. The shell stays usable.

### Tests

Two tests in `tests/acp-test.el`, both driving a real client whose
`make-process` is stubbed so the `:filter` can be captured and fed
newline-delimited notifications. A handler that calls
`(signal 'quit nil)` stands in for `C-g` arriving mid-drain.

- `acp-test-drain-survives-quitting-notification-handler` — messages
  queued behind the quitting handler still get routed.
- `acp-test-drain-unwedges-queue-after-quitting-handler` — messages
  arriving *after* the quit still get routed.

Verified they capture the regression:

```
without the patch:  Ran 13 tests, 11 as expected, 2 unexpected  (both new tests FAILED)
with the patch:     Ran 13 tests, 13 as expected, 0 unexpected
```

### A deliberate omission

Adding `quit` to the three `condition-case-unless-debug` handler lists
would additionally avoid dropping the in-flight chunk. I left it out:
swallowing `quit` inside the handlers, combined with the rescheduling
above, would make a pathological render loop uninterruptible. Keeping
`quit` propagating means `C-g` still aborts the current message while
the queue survives, which seems like the better trade. Happy to add it
if you'd rather have zero text loss.
